### PR TITLE
Fix `$flavor->{'id'}` Item ID(s)

### DIFF
--- a/Pasteboard.xs
+++ b/Pasteboard.xs
@@ -579,7 +579,7 @@ xs_pbl_all( void *pbref, SV *sv_id, int want_data, SV *sv_conforms_to )
 
 		( void ) hv_stores( flvr, "flags", newSVuv( flags ) );
 
-		( void ) hv_stores( flvr, "id", newSVuv( id ) );
+		( void ) hv_stores( flvr, "id", newSVuv( item_id ) );
 
 		CF_TO_SV_CHECKED( sv_data, flavor_type );
 		( void ) hv_stores( flvr, "flavor", sv_data );

--- a/Pasteboard.xs
+++ b/Pasteboard.xs
@@ -360,7 +360,7 @@ xs_pbl_paste( void *pbref, SV *id, SV *sv_flavor )
 	} else {
 	    EXTEND( SP, 3 );
 	    PUSHs( sv_2mortal( newSViv( status ) ) );
-	    if ( data == NULL ) {
+	    if ( sv_data == NULL ) {
 		PUSHs( sv_2mortal( newSV(0) ) );
 	    } else {
 	        PUSHs( sv_2mortal( sv_data ) );

--- a/Pasteboard.xs
+++ b/Pasteboard.xs
@@ -327,7 +327,7 @@ xs_pbl_paste( void *pbref, SV *id, SV *sv_flavor )
 	    status = PasteboardGetItemIdentifier( pbref, item_inx, &item_id );
 	    if ( status ) goto cleanup;
 
-	    if ( ! any && item_id != ( PasteboardItemID ) id )
+	    if ( ! any && item_id != ( PasteboardItemID ) cid )
 		continue;
 
 	    status = PasteboardCopyItemFlavorData(


### PR DESCRIPTION
When copying multiple items (e.g., Finder » Cmd+Click two images), `xs_pbl_all()` wasn't updating the `$flavor->{'id'}` values (It was putting in the `$pb->{'id'}`, which is usually zero/empty.)

Similarly, `xs_pbl_paste()` was checking the wrong `id`/`cid` and the wrong `data`/`sv_data`